### PR TITLE
Cleanup env options

### DIFF
--- a/XIV on Mac/Util.swift
+++ b/XIV on Mac/Util.swift
@@ -160,7 +160,7 @@ struct Util {
         env["XL_WINEONLINUX"] = "true"
         env["XL_WINEONMAC"] = "true"
         //env["DYLD_PRINT_LIBRARIES"] = "YES"
-        env["DYLD_FALLBACK_LIBRARY_PATH"] = Bundle.main.url(forResource: "lib", withExtension: "", subdirectory: "wine")!.path + ":/usr/lib:/usr/libexec:/usr/lib/system:/opt/X11/lib:/opt/local/lib:/usr/X11/lib:/usr/X11R6/lib"
+        env["DYLD_FALLBACK_LIBRARY_PATH"] = Bundle.main.url(forResource: "lib", withExtension: "", subdirectory: "wine")!.path + ":/opt/local/lib:/usr/local/lib:/usr/lib:/usr/libexec:/usr/lib/system:/opt/X11/lib"
         env["DYLD_VERSIONED_LIBRARY_PATH"] = env["DYLD_FALLBACK_LIBRARY_PATH"]
         return env
     }

--- a/XIV on Mac/Util.swift
+++ b/XIV on Mac/Util.swift
@@ -159,9 +159,6 @@ struct Util {
         env["DXVK_FRAME_RATE"] = dxvkOptions.getMaxFramerate()
         env["XL_WINEONLINUX"] = "true"
         env["XL_WINEONMAC"] = "true"
-        env["MVK_CONFIG_FAST_MATH_ENABLED"] = "1"
-        env["MVK_CONFIG_RESUME_LOST_DEVICE"] = "1"
-        env["MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE"] = "1"
         //env["DYLD_PRINT_LIBRARIES"] = "YES"
         env["DYLD_FALLBACK_LIBRARY_PATH"] = Bundle.main.url(forResource: "lib", withExtension: "", subdirectory: "wine")!.path + ":/usr/lib:/usr/libexec:/usr/lib/system:/opt/X11/lib:/opt/local/lib:/usr/X11/lib:/usr/X11R6/lib"
         env["DYLD_VERSIONED_LIBRARY_PATH"] = env["DYLD_FALLBACK_LIBRARY_PATH"]


### PR DESCRIPTION
Removed unneeded MoltenVK env options and corrected `DYLD_FALLBACK_LIBRARY_PATH` order.

`MVK_CONFIG_FAST_MATH_ENABLED` is enabled by default in upstream, the other two options are enabled by default in MoltenVK-DXVK

`DYLD_FALLBACK_LIBRARY_PATH` was mapping the libraries badly (possibly copied from old Wineskin sources?) we actually require third-party libraries to be checked before Apple provided libraries.\
Macports is placed first as it avoids Apple provided libraries, brew second as it provides none system libraries and sometimes resolves system libraries (uncommon).\
XQuartz is dead last to avoid possible conflicts but really isn’t even needed outside of winex11 being built as from CX19 sources winex11 isn’t fixed for 32-on-64 anyway.