### PR TITLE
Drop support for Intel GPUs

### DIFF
--- a/XIV on Mac/Util.swift
+++ b/XIV on Mac/Util.swift
@@ -159,6 +159,7 @@ struct Util {
         env["DXVK_FRAME_RATE"] = dxvkOptions.getMaxFramerate()
         env["XL_WINEONLINUX"] = "true"
         env["XL_WINEONMAC"] = "true"
+        env["MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE"] = "0"
         //env["DYLD_PRINT_LIBRARIES"] = "YES"
         env["DYLD_FALLBACK_LIBRARY_PATH"] = Bundle.main.url(forResource: "lib", withExtension: "", subdirectory: "wine")!.path + ":/opt/local/lib:/usr/local/lib:/usr/lib:/usr/libexec:/usr/lib/system:/opt/X11/lib"
         env["DYLD_VERSIONED_LIBRARY_PATH"] = env["DYLD_FALLBACK_LIBRARY_PATH"]


### PR DESCRIPTION
As discussed in Discord, drop support for running FFXIV on Intel GPUs due to low performance and graphical artefacts.