### PR TITLE
DXVK is failing to install initially because the ~/Library/Applicatio…

### DIFF
--- a/XIV on Mac/AppDelegate.swift
+++ b/XIV on Mac/AppDelegate.swift
@@ -22,12 +22,12 @@ import Sparkle
         checkForRosetta()
         Steam.initAPI()
         sparkle.updater.checkForUpdatesInBackground()
+        Util.make(dir: Wine.xomData.path)
+        Util.make(dir: Util.cache.path)
         if DXVK.shouldUpdate {
             DXVK.install()
         }
         settingsWinController = storyboard.instantiateController(withIdentifier: "SettingsWindow") as? NSWindowController
-        Util.make(dir: Wine.xomData.path)
-        Util.make(dir: Util.cache.path)
         SocialIntegration.discord.setPresence()
     }
 


### PR DESCRIPTION
…n Support/XIV on Mac/ prefix folder hasn't been created yet. The "File not found" error was being misattributed to the *source* path when it was in fact the target path.

Moving the Util.make() calls to above the DXVK installer fixes the problem.

To test:
defaults delete dezent.XIV-on-Mac
(Note that deleting the plist manually from ~/L/Preferences is *not* sufficient because CFPrefsd will maintain a version in memory and re-write the plist)
Move or delete  ~/Library/Application Support/XIV on Mac/