### PR TITLE
Added a check for compatible GPUs.

### DIFF
--- a/XIV on Mac/AppDelegate.swift
+++ b/XIV on Mac/AppDelegate.swift
@@ -25,6 +25,7 @@ import AppMover
         launchWinController?.showWindow(self)
         actAutoLaunch.state = ACT.autoLaunch ? .on : .off
         bhAutoLaunch.state = ACT.autoLaunchBH ? .on : .off
+        checkGPUSupported()
         checkForRosetta()
         Steam.initAPI()
         sparkle.updater.checkForUpdatesInBackground()
@@ -80,6 +81,23 @@ import AppMover
             }
         }
     #endif
+    }
+    
+    func checkGPUSupported() {
+        if (!Util.supportedGPU())
+        {
+            let alert: NSAlert = NSAlert()
+            alert.messageText = NSLocalizedString("UNSUPPORTED_GPU", comment: "")
+            alert.informativeText = NSLocalizedString("UNSUPPORTED_GPU_INFORMATIVE", comment: "")
+            alert.alertStyle = .critical
+            alert.addButton(withTitle:NSLocalizedString("OK_BUTTON", comment: ""))
+            alert.addButton(withTitle:NSLocalizedString("SEE_COMPATABILITY_BUTTON", comment: ""))
+            alert.icon = NSImage(named: "CfgCheckProbFailed.tiff")
+            let result = alert.runModal()
+            if result == .alertSecondButtonReturn {
+                NSWorkspace.shared.open(URL(string: "https://www.xivmac.com/compatibility-database")!)
+            }
+        }
     }
     
     @IBAction func openPrefix(_ sender: Any) {

--- a/XIV on Mac/FirstAid/FirstAidController.swift
+++ b/XIV on Mac/FirstAid/FirstAidController.swift
@@ -106,6 +106,9 @@ class FirstAidController: NSViewController, NSTableViewDelegate, NSTableViewData
             }
             try FileManager.default.copyItem(at: FFXIVApp.configURL, to: xomConfigBackupURL)
             try FileManager.default.removeItem(at: FFXIVApp.configURL)
+            let defaultCfgURL = Bundle.main.url(forResource: "FFXIV-MacDefault", withExtension: "cfg")!
+            try FileManager.default.copyItem(at: defaultCfgURL, to: FFXIVApp.configURL)
+
             alert.alertStyle = .informational
             alert.messageText = NSLocalizedString("GAME_CONFIG_RESET", comment: "")
             alert.informativeText = NSLocalizedString("GAME_CONFIG_RESET_INFORMATIVE", comment: "")

--- a/XIV on Mac/en.lproj/Localizable.strings
+++ b/XIV on Mac/en.lproj/Localizable.strings
@@ -47,6 +47,10 @@
 "GAME_CONFIG_RESET_FAILED" = "Resetting Configuration Failed";
 "GAME_CONFIG_RESET_FAILED_INFORMATIVE" = "Unable to reset configuration. You may need to grant XIV On Mac access to your Downloads folder in System Preferences, Security.";
 
+"UNSUPPORTED_GPU" = "No Supported GPU Found";
+"UNSUPPORTED_GPU_INFORMATIVE" = "XIV On Mac did not find any supported GPUs in your Mac. If you continue, the game may fail to function, crash, or otherwise perform in a substandard manner. For more details please see our Compatibility List.";
+"SEE_COMPATABILITY_BUTTON" = "Compatibility List";
+
 "ROSETTA_REQUIRED" = "Rosetta 2 is Required.";
 "ROSETTA_REQUIRED_INFORMATIVE" = "XIV On Mac requires Apple's Rosetta 2 to be installed in order to function on your Apple Silicon Mac. If you choose not to install, your game will not start. Would you like to start the Rosetta installer now?";
 "ROSETTA_REQUIRED_INSTALL_BUTTON" = "Install Rosetta";


### PR DESCRIPTION
Compatible is defined as:
- On Intel Macs, any AMD GPU
- On Apple Silicon Macs, everything.
Other GPUs may *also* exist, EG: An iGPU along with an eGPU, or an Intel MBP with Discrete graphics and integrated. As long as we find a supported one exists we're happy.

Secondarily, fixed a bug with the "Reset Configuration" where we weren't putting back the default Mac config, which could allow the Windows license to use HBAO.