### PR TITLE
Addressed two bugs:

### DIFF
--- a/XIV on Mac/Launcher/Settings.swift
+++ b/XIV on Mac/Launcher/Settings.swift
@@ -39,6 +39,11 @@ public struct Settings {
         }
     }
     
+    static func setDefaultGamepath() {
+        storage.removeObject(forKey: gamePathKey)
+        syncToXL()
+    }
+    
     private static let gameConfigPathKey = "GameConfigPath"
     static let defaultGameConfigLoc = Util.applicationSupport.appendingPathComponent("ffxivConfig")
     static var gameConfigPath: URL {

--- a/XIV on Mac/PrefixMigrator.swift
+++ b/XIV on Mac/PrefixMigrator.swift
@@ -33,6 +33,12 @@ class PrefixMigrator {
             }
         }
         
+        if Settings.gamePath.path.hasPrefix(Util.applicationSupport.appendingPathComponent("game/", isDirectory: true).path) {
+            Log.information("Prefix Migration: Setting GamePath to new default.")
+            // Preference was set to the default location explicitly previously
+            Settings.setDefaultGamepath()
+        }
+        
         // Clean up items (EG: old logs) from old location
         let deleteItems : [URL] = [Util.applicationSupport.appendingPathComponent("app.log", isDirectory: false),
                                    Util.applicationSupport.appendingPathComponent("wine.log", isDirectory: false)]
@@ -56,7 +62,7 @@ class PrefixMigrator {
             let oldProgramFilesXIVOnMacPath = oldPrefixPath.appendingPathComponent("drive_c/Program Files/XIV on Mac/", isDirectory: true)
             let itemsToRetrieve : [(URL,URL)] = [
                 // First we move the game data itself
-                (oldPrefixPath.appendingPathComponent("drive_c/Program Files (x86)/SquareEnix/", isDirectory: true),
+                (oldPrefixPath.appendingPathComponent("drive_c/Program Files (x86)/SquareEnix/FINAL FANTASY XIV - A Realm Reborn/", isDirectory: true),
                  Util.applicationSupport.appendingPathComponent("ffxiv/", isDirectory: true)
                 ),
                 


### PR DESCRIPTION
- GamePath CFPref was not being updated to the new Prefix location if it was set to a default location in a previous XOM.
- Game content files source directory was incorrect - we needed one level further in so that 'game/' and 'boot/' ended up as top-level items inside /ffxiv