### PR TITLE
Bump moltenvk modern to v.1.1.10-ga909822

### DIFF
--- a/XIV on Mac/Wine.swift
+++ b/XIV on Mac/Wine.swift
@@ -35,8 +35,9 @@ struct Wine {
         addEnviromentVariable("DYLD_FALLBACK_LIBRARY_PATH", libSearchPathsConcat)
         addEnviromentVariable("DYLD_VERSIONED_LIBRARY_PATH", libSearchPathsConcat)
         addEnviromentVariable("LANG", "en_US")
-        addEnviromentVariable("MVK_CONFIG_RESUME_LOST_DEVICE", "1")
-        addEnviromentVariable("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1")
+        addEnviromentVariable("MVK_ALLOW_METAL_FENCES", "1")             // XXX Required by DXVK for Apple/NVidia GPUs (better FPS than CPU Emulation)
+        addEnviromentVariable("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1") // XXX Required by DXVK for Intel/NVidia GPUs
+        addEnviromentVariable("MVK_CONFIG_RESUME_LOST_DEVICE", "1")      // XXX Required by WINE (doesn't handle VK_ERROR_DEVICE_LOST correctly)
         addEnviromentVariable("DXVK_HUD", Dxvk.options.getHud())
         addEnviromentVariable("DXVK_ASYNC", Dxvk.options.getAsync())
         addEnviromentVariable("DXVK_FRAME_RATE", Dxvk.options.getMaxFramerate())


### PR DESCRIPTION
- Bumps Modern to MoltenVK-v.1.1.10-[ga909822](https://github.com/Gcenx/MoltenVK/releases/download/v1.1.10/macos-1.1.10-ga909822.tar.xz) (only x86_64 arch)
- Add back `MVK_ALLOW_METAL_FENCES=1` this was used to improve performance on Apple/NVidia GPUs
- Added notes to the MVK env options explaining _why_ it's being set