### PR TITLE
Tappable item controls + timer fix

### DIFF
--- a/XIV on Mac/Launcher/CarouselView.swift
+++ b/XIV on Mac/Launcher/CarouselView.swift
@@ -14,7 +14,7 @@ struct CarouselView<Content>: View where Content: View {
 
     @State private var offset = CGFloat.zero
     @State private var dragging = false
-    @State private var timer = Timer.publish(every: 5, on: .current, in: .common).autoconnect()
+    @State private var timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     init(index: Binding<Int>, maxIndex: Int, @ViewBuilder content: @escaping () -> Content) {
         self._index = index

--- a/XIV on Mac/Launcher/CarouselView.swift
+++ b/XIV on Mac/Launcher/CarouselView.swift
@@ -63,12 +63,20 @@ struct CarouselView<Content>: View where Content: View {
             resetTimer()
         }
         .onChange(of: dragging) { _ in
-            resetTimer()
+            if dragging {
+                stopTimer()
+            } else {
+                resetTimer()
+            }
         }
     }
     
     private func resetTimer() {
         timer = Timer.publish(every: 5, on: .current, in: .common).autoconnect()
+    }
+    
+    private func stopTimer() {
+        timer.upstream.connect().cancel()
     }
 
     func offset(in geometry: GeometryProxy) -> CGFloat {

--- a/XIV on Mac/Launcher/CarouselView.swift
+++ b/XIV on Mac/Launcher/CarouselView.swift
@@ -87,7 +87,11 @@ struct ItemControl: View {
                 Circle()
                     .strokeBorder(Color.black, lineWidth: 1)
                     .background(Circle().foregroundColor(index == self.index ? Color.white : Color.gray))
-                    .frame(width: 8, height: 8)
+                    .frame(width: 12, height: 12)
+                    .opacity(0.4)
+                    .onTapGesture {
+                        self.index = index
+                    }
             }
         }
         .padding(15)


### PR DESCRIPTION
Made the controls slightly bigger and tappable, added a bit of opacity so that they do not clash with the UI too much.
Also fixed the timer, and a found a way to actually allow to reset it by listening to some state changes.