### PR TITLE
Alt/command key mapping options

### DIFF
--- a/XIV on Mac/Settings/SettingsGeneralTabView.swift
+++ b/XIV on Mac/Settings/SettingsGeneralTabView.swift
@@ -12,126 +12,126 @@ struct SettingsGeneralTabView: View {
     @StateObject private var viewModel = ViewModel()
 
     var body: some View {
-		ZStack(alignment: .bottomTrailing) {
-			VStack {
-				VStack {
-					HStack {
-						Text("SETTINGS_GENERAL_TITLE_LICENSE")
-							.font(.headline)
-						
-						Spacer()
-					}
-					
-					Text("SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB")
-						.multilineTextAlignment(.leading)
-						.lineLimit(nil)
-						.frame(maxWidth: .infinity, alignment: .leading)
-						.font(.callout)
-					
-					HStack {
-						Picker(selection: $viewModel.language, label: Text("SETTINGS_LANGUAGE_PICKER")) {
-							Text("SETTINGS_LANGUAGE_JAPANESE").tag(FFXIVLanguage.japanese)
-							Text("SETTINGS_LANGUAGE_ENGLISH").tag(FFXIVLanguage.english)
-							Text("SETTINGS_LANGUAGE_FRENCH").tag(FFXIVLanguage.french)
-							Text("SETTINGS_LANGUAGE_GERMAN").tag(FFXIVLanguage.german)
-						}
-						.padding(.bottom)
-						.fixedSize(horizontal: true, vertical: false)
-						
-						Picker(selection: $viewModel.platform, label: Text("SETTINGS_PLATFORM_PICKER")) {
-							Text("SETTINGS_PLATFORM_MAC").tag(FFXIVPlatform.mac)
-							Text("SETTINGS_PLATFORM_WINDOWS").tag(FFXIVPlatform.windows)
-							Text("SETTINGS_PLATFORM_STEAM").tag(FFXIVPlatform.steam)
-						}
-						.padding(.bottom)
-						.fixedSize(horizontal: true, vertical: false)
-						
-						Spacer()
-					}
-					
-					HStack {
-						Toggle(isOn: $viewModel.freeTrial) {
-							Text("SETTINGS_FREE_TRIAL")
-						}
-						.fixedSize(horizontal: true, vertical: false)
-						
-						Spacer()
-					}
-					
-					Text("SETTINGS_GENERAL_FREE_TRIAL_BLURB")
-						.multilineTextAlignment(.leading)
-						.lineLimit(nil)
-						.frame(maxWidth: .infinity, alignment: .leading)
-						.font(.callout)
-				}
-				.padding([.leading, .trailing, .top])
-				
-				VStack {
-					HStack {
-						Text("SETTINGS_GENERAL_TITLE_NETWORK")
-							.font(.headline)
-						
-						Spacer()
-					}
-					
-					HStack {
-						Toggle(isOn: $viewModel.limitDownloadEnabled) {
-							Text("SETTINGS_DOWNLOAD_LIMIT")
-						}
-						
-						TextField("SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER", text: $viewModel.limitDownloadSpeed)
-							.fixedSize(horizontal: true, vertical: false)
-							.disabled(!viewModel.limitDownloadEnabled)
-						
-						Text("SETTINGS_DOWNLOAD_LIMIT_UNITS")
-						Spacer()
-					}
-				}
-				.padding([.leading, .trailing, .top])
-				
-				HStack {
-					VStack {
-						HStack {
-							Text("SETTINGS_GENERAL_TITLE_INPUT")
-								.font(.headline)
-							
-							Spacer()
-						}
-						
-						HStack {
-							Picker("SETTINGS_GENERAL_INPUT_LEFT_OPTION", selection: $viewModel.leftOptionIsAlt) {
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
-							}
-							
-							Picker("SETTINGS_GENERAL_INPUT_RIGHT_OPTION", selection: $viewModel.rightOptionIsAlt) {
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
-							}
-						}
-						
-						HStack {
-							Picker("SETTINGS_GENERAL_INPUT_LEFT_COMMAND", selection: $viewModel.leftCommandIsCtrl) {
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
-							}
-							
-							Picker("SETTINGS_GENERAL_INPUT_RIGHT_COMMAND", selection: $viewModel.rightCommandIsCtrl) {
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
-								Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
-							}
-						}
-					}
-					
-					Spacer(minLength: 140)
-				}
-				.padding([.leading, .trailing, .top])
-				
-				Spacer()
-			}
-			Image(nsImage: NSImage(named: "PrefsGeneral") ?? NSImage())
-				.padding()
-		}
+        ZStack(alignment: .bottomTrailing) {
+            VStack {
+                VStack {
+                    HStack {
+                        Text("SETTINGS_GENERAL_TITLE_LICENSE")
+                            .font(.headline)
+                        
+                        Spacer()
+                    }
+                    
+                    Text("SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB")
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(nil)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.callout)
+                    
+                    HStack {
+                        Picker(selection: $viewModel.language, label: Text("SETTINGS_LANGUAGE_PICKER")) {
+                            Text("SETTINGS_LANGUAGE_JAPANESE").tag(FFXIVLanguage.japanese)
+                            Text("SETTINGS_LANGUAGE_ENGLISH").tag(FFXIVLanguage.english)
+                            Text("SETTINGS_LANGUAGE_FRENCH").tag(FFXIVLanguage.french)
+                            Text("SETTINGS_LANGUAGE_GERMAN").tag(FFXIVLanguage.german)
+                        }
+                        .padding(.bottom)
+                        .fixedSize(horizontal: true, vertical: false)
+                        
+                        Picker(selection: $viewModel.platform, label: Text("SETTINGS_PLATFORM_PICKER")) {
+                            Text("SETTINGS_PLATFORM_MAC").tag(FFXIVPlatform.mac)
+                            Text("SETTINGS_PLATFORM_WINDOWS").tag(FFXIVPlatform.windows)
+                            Text("SETTINGS_PLATFORM_STEAM").tag(FFXIVPlatform.steam)
+                        }
+                        .padding(.bottom)
+                        .fixedSize(horizontal: true, vertical: false)
+                        
+                        Spacer()
+                    }
+                    
+                    HStack {
+                        Toggle(isOn: $viewModel.freeTrial) {
+                            Text("SETTINGS_FREE_TRIAL")
+                        }
+                        .fixedSize(horizontal: true, vertical: false)
+                        
+                        Spacer()
+                    }
+                    
+                    Text("SETTINGS_GENERAL_FREE_TRIAL_BLURB")
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(nil)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.callout)
+                }
+                .padding([.leading, .trailing, .top])
+                
+                VStack {
+                    HStack {
+                        Text("SETTINGS_GENERAL_TITLE_NETWORK")
+                            .font(.headline)
+                        
+                        Spacer()
+                    }
+                    
+                    HStack {
+                        Toggle(isOn: $viewModel.limitDownloadEnabled) {
+                            Text("SETTINGS_DOWNLOAD_LIMIT")
+                        }
+                        
+                        TextField("SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER", text: $viewModel.limitDownloadSpeed)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .disabled(!viewModel.limitDownloadEnabled)
+                        
+                        Text("SETTINGS_DOWNLOAD_LIMIT_UNITS")
+                        Spacer()
+                    }
+                }
+                .padding([.leading, .trailing, .top])
+                
+                HStack {
+                    VStack {
+                        HStack {
+                            Text("SETTINGS_GENERAL_TITLE_INPUT")
+                                .font(.headline)
+                            
+                            Spacer()
+                        }
+                        
+                        HStack {
+                            Picker("SETTINGS_GENERAL_INPUT_LEFT_OPTION", selection: $viewModel.leftOptionIsAlt) {
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
+                            }
+                            
+                            Picker("SETTINGS_GENERAL_INPUT_RIGHT_OPTION", selection: $viewModel.rightOptionIsAlt) {
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
+                            }
+                        }
+                        
+                        HStack {
+                            Picker("SETTINGS_GENERAL_INPUT_LEFT_COMMAND", selection: $viewModel.leftCommandIsCtrl) {
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
+                            }
+                            
+                            Picker("SETTINGS_GENERAL_INPUT_RIGHT_COMMAND", selection: $viewModel.rightCommandIsCtrl) {
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
+                                Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
+                            }
+                        }
+                    }
+                    
+                    Spacer(minLength: 140)
+                }
+                .padding([.leading, .trailing, .top])
+                
+                Spacer()
+            }
+            Image(nsImage: NSImage(named: "PrefsGeneral") ?? NSImage())
+                .padding()
+        }
     }
 }
 
@@ -162,22 +162,22 @@ extension SettingsGeneralTabView {
         @Published var limitDownloadSpeed: String = .init(HTTPClient.maxSpeed) {
             didSet { updateHTTPMaxSpeed() }
         }
-		
-		@Published var leftOptionIsAlt: Bool = !Wine.leftOptionIsAlt {
-			didSet { Wine.leftOptionIsAlt = leftOptionIsAlt }
-		}
-		
-		@Published var rightOptionIsAlt: Bool = !Wine.rightOptionIsAlt {
-			didSet { Wine.rightOptionIsAlt = rightOptionIsAlt }
-		}
-		
-		@Published var leftCommandIsCtrl: Bool = !Wine.leftCommandIsCtrl {
-			didSet { Wine.leftCommandIsCtrl = leftCommandIsCtrl }
-		}
-		
-		@Published var rightCommandIsCtrl: Bool = !Wine.rightCommandIsCtrl {
-			didSet { Wine.rightCommandIsCtrl = rightCommandIsCtrl }
-		}
+        
+        @Published var leftOptionIsAlt: Bool = !Wine.leftOptionIsAlt {
+            didSet { Wine.leftOptionIsAlt = leftOptionIsAlt }
+        }
+        
+        @Published var rightOptionIsAlt: Bool = !Wine.rightOptionIsAlt {
+            didSet { Wine.rightOptionIsAlt = rightOptionIsAlt }
+        }
+        
+        @Published var leftCommandIsCtrl: Bool = !Wine.leftCommandIsCtrl {
+            didSet { Wine.leftCommandIsCtrl = leftCommandIsCtrl }
+        }
+        
+        @Published var rightCommandIsCtrl: Bool = !Wine.rightCommandIsCtrl {
+            didSet { Wine.rightCommandIsCtrl = rightCommandIsCtrl }
+        }
 
         private func updateHTTPMaxSpeed() {
             HTTPClient.maxSpeed = limitDownloadEnabled ? Double(limitDownloadSpeed) ?? 0.0 : 0.0

--- a/XIV on Mac/Settings/SettingsGeneralTabView.swift
+++ b/XIV on Mac/Settings/SettingsGeneralTabView.swift
@@ -12,71 +12,126 @@ struct SettingsGeneralTabView: View {
     @StateObject private var viewModel = ViewModel()
 
     var body: some View {
-        VStack {
-            Text("SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB")
-                .multilineTextAlignment(.leading)
-                .lineLimit(nil)
-                .padding([.top, .leading, .trailing])
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack {
-                Picker(selection: $viewModel.language, label: Text("SETTINGS_LANGUAGE_PICKER")) {
-                    Text("SETTINGS_LANGUAGE_JAPANESE").tag(FFXIVLanguage.japanese)
-                    Text("SETTINGS_LANGUAGE_ENGLISH").tag(FFXIVLanguage.english)
-                    Text("SETTINGS_LANGUAGE_FRENCH").tag(FFXIVLanguage.french)
-                    Text("SETTINGS_LANGUAGE_GERMAN").tag(FFXIVLanguage.german)
-                }
-                .padding([.leading, .bottom, .trailing])
-                .fixedSize(horizontal: true, vertical: false)
-
-                Picker(selection: $viewModel.platform, label: Text("SETTINGS_PLATFORM_PICKER")) {
-                    Text("SETTINGS_PLATFORM_MAC").tag(FFXIVPlatform.mac)
-                    Text("SETTINGS_PLATFORM_WINDOWS").tag(FFXIVPlatform.windows)
-                    Text("SETTINGS_PLATFORM_STEAM").tag(FFXIVPlatform.steam)
-                }
-                .padding([.leading, .bottom, .trailing])
-                .fixedSize(horizontal: true, vertical: false)
-
-                Spacer()
-            }
-
-            HStack {
-                Toggle(isOn: $viewModel.freeTrial) {
-                    Text("SETTINGS_FREE_TRIAL")
-                }
-                .padding(.leading)
-                Spacer()
-            }
-
-            Text("SETTINGS_GENERAL_FREE_TRIAL_BLURB")
-                .multilineTextAlignment(.leading)
-                .lineLimit(nil)
-                .padding(.horizontal)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack {
-                Toggle(isOn: $viewModel.limitDownloadEnabled) {
-                    Text("SETTINGS_DOWNLOAD_LIMIT")
-                }
-                .padding(.leading)
-
-                TextField("SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER", text: $viewModel.limitDownloadSpeed)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .disabled(!viewModel.limitDownloadEnabled)
-
-                Text("SETTINGS_DOWNLOAD_LIMIT_UNITS")
-                Spacer()
-                    .padding(.horizontal)
-            }
-
-            Spacer()
-
-            HStack {
-                Spacer()
-                Image(nsImage: NSImage(named: "PrefsGeneral") ?? NSImage())
-                    .padding(.all)
-            }
-        }
+		ZStack(alignment: .bottomTrailing) {
+			VStack {
+				VStack {
+					HStack {
+						Text("SETTINGS_GENERAL_TITLE_LICENSE")
+							.font(.headline)
+						
+						Spacer()
+					}
+					
+					Text("SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB")
+						.multilineTextAlignment(.leading)
+						.lineLimit(nil)
+						.frame(maxWidth: .infinity, alignment: .leading)
+						.font(.callout)
+					
+					HStack {
+						Picker(selection: $viewModel.language, label: Text("SETTINGS_LANGUAGE_PICKER")) {
+							Text("SETTINGS_LANGUAGE_JAPANESE").tag(FFXIVLanguage.japanese)
+							Text("SETTINGS_LANGUAGE_ENGLISH").tag(FFXIVLanguage.english)
+							Text("SETTINGS_LANGUAGE_FRENCH").tag(FFXIVLanguage.french)
+							Text("SETTINGS_LANGUAGE_GERMAN").tag(FFXIVLanguage.german)
+						}
+						.padding(.bottom)
+						.fixedSize(horizontal: true, vertical: false)
+						
+						Picker(selection: $viewModel.platform, label: Text("SETTINGS_PLATFORM_PICKER")) {
+							Text("SETTINGS_PLATFORM_MAC").tag(FFXIVPlatform.mac)
+							Text("SETTINGS_PLATFORM_WINDOWS").tag(FFXIVPlatform.windows)
+							Text("SETTINGS_PLATFORM_STEAM").tag(FFXIVPlatform.steam)
+						}
+						.padding(.bottom)
+						.fixedSize(horizontal: true, vertical: false)
+						
+						Spacer()
+					}
+					
+					HStack {
+						Toggle(isOn: $viewModel.freeTrial) {
+							Text("SETTINGS_FREE_TRIAL")
+						}
+						.fixedSize(horizontal: true, vertical: false)
+						
+						Spacer()
+					}
+					
+					Text("SETTINGS_GENERAL_FREE_TRIAL_BLURB")
+						.multilineTextAlignment(.leading)
+						.lineLimit(nil)
+						.frame(maxWidth: .infinity, alignment: .leading)
+						.font(.callout)
+				}
+				.padding([.leading, .trailing, .top])
+				
+				VStack {
+					HStack {
+						Text("SETTINGS_GENERAL_TITLE_NETWORK")
+							.font(.headline)
+						
+						Spacer()
+					}
+					
+					HStack {
+						Toggle(isOn: $viewModel.limitDownloadEnabled) {
+							Text("SETTINGS_DOWNLOAD_LIMIT")
+						}
+						
+						TextField("SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER", text: $viewModel.limitDownloadSpeed)
+							.fixedSize(horizontal: true, vertical: false)
+							.disabled(!viewModel.limitDownloadEnabled)
+						
+						Text("SETTINGS_DOWNLOAD_LIMIT_UNITS")
+						Spacer()
+					}
+				}
+				.padding([.leading, .trailing, .top])
+				
+				HStack {
+					VStack {
+						HStack {
+							Text("SETTINGS_GENERAL_TITLE_INPUT")
+								.font(.headline)
+							
+							Spacer()
+						}
+						
+						HStack {
+							Picker("SETTINGS_GENERAL_INPUT_LEFT_OPTION", selection: $viewModel.leftOptionIsAlt) {
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
+							}
+							
+							Picker("SETTINGS_GENERAL_INPUT_RIGHT_OPTION", selection: $viewModel.rightOptionIsAlt) {
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT").tag(true)
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION").tag(false)
+							}
+						}
+						
+						HStack {
+							Picker("SETTINGS_GENERAL_INPUT_LEFT_COMMAND", selection: $viewModel.leftCommandIsCtrl) {
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
+							}
+							
+							Picker("SETTINGS_GENERAL_INPUT_RIGHT_COMMAND", selection: $viewModel.rightCommandIsCtrl) {
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_CTRL").tag(true)
+								Text("SETTINGS_GENERAL_INPUT_BUTTON_ALT").tag(false)
+							}
+						}
+					}
+					
+					Spacer(minLength: 140)
+				}
+				.padding([.leading, .trailing, .top])
+				
+				Spacer()
+			}
+			Image(nsImage: NSImage(named: "PrefsGeneral") ?? NSImage())
+				.padding()
+		}
     }
 }
 
@@ -107,6 +162,22 @@ extension SettingsGeneralTabView {
         @Published var limitDownloadSpeed: String = .init(HTTPClient.maxSpeed) {
             didSet { updateHTTPMaxSpeed() }
         }
+		
+		@Published var leftOptionIsAlt: Bool = !Wine.leftOptionIsAlt {
+			didSet { Wine.leftOptionIsAlt = leftOptionIsAlt }
+		}
+		
+		@Published var rightOptionIsAlt: Bool = !Wine.rightOptionIsAlt {
+			didSet { Wine.rightOptionIsAlt = rightOptionIsAlt }
+		}
+		
+		@Published var leftCommandIsCtrl: Bool = !Wine.leftCommandIsCtrl {
+			didSet { Wine.leftCommandIsCtrl = leftCommandIsCtrl }
+		}
+		
+		@Published var rightCommandIsCtrl: Bool = !Wine.rightCommandIsCtrl {
+			didSet { Wine.rightCommandIsCtrl = rightCommandIsCtrl }
+		}
 
         private func updateHTTPMaxSpeed() {
             HTTPClient.maxSpeed = limitDownloadEnabled ? Double(limitDownloadSpeed) ?? 0.0 : 0.0

--- a/XIV on Mac/Wine.swift
+++ b/XIV on Mac/Wine.swift
@@ -119,6 +119,50 @@ struct Wine {
             UserDefaults.standard.set(_retina, forKey: retinaSettingKey)
         }
     }
+	
+	private static let leftOptionIsAltSettingKey = "LeftOptionIsAlt"
+	static var leftOptionIsAlt: Bool {
+		get {
+			Util.getSetting(settingKey: leftOptionIsAltSettingKey, defaultValue: false)
+		}
+		set(_leftOpenIsAlt) {
+			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftOptionIsAlt", data: _leftOpenIsAlt ? "y" : "n")
+			UserDefaults.standard.set(_leftOpenIsAlt, forKey: leftOptionIsAltSettingKey)
+		}
+	}
+	
+	private static let rightOptionIsAltSettingKey = "RightOptionIsAlt"
+	static var rightOptionIsAlt: Bool {
+		get {
+			Util.getSetting(settingKey: rightOptionIsAltSettingKey, defaultValue: false)
+		}
+		set(_rightOpenIsAlt) {
+			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightOptionIsAlt", data: _rightOpenIsAlt ? "y" : "n")
+			UserDefaults.standard.set(_rightOpenIsAlt, forKey: rightOptionIsAltSettingKey)
+		}
+	}
+	
+	private static let leftCommandIsCtrlSettingKey = "LeftCommandIsCtrl"
+	static var leftCommandIsCtrl: Bool {
+		get {
+			Util.getSetting(settingKey: leftCommandIsCtrlSettingKey, defaultValue: false)
+		}
+		set(_leftCommandIsCtrl) {
+			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftCommandIsCtrl", data: _leftCommandIsCtrl ? "y" : "n")
+			UserDefaults.standard.set(_leftCommandIsCtrl, forKey: leftCommandIsCtrlSettingKey)
+		}
+	}
+	
+	private static let rightCommandIsCtrlSettingKey = "RightCommandIsCtrl"
+	static var rightCommandIsCtrl: Bool {
+		get {
+			Util.getSetting(settingKey: rightCommandIsCtrlSettingKey, defaultValue: false)
+		}
+		set(_rightCommandIsCtrl) {
+			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightCommandIsCtrl", data: _rightCommandIsCtrl ? "y" : "n")
+			UserDefaults.standard.set(_rightCommandIsCtrl, forKey: rightCommandIsCtrlSettingKey)
+		}
+	}
     
     private static var timebase: mach_timebase_info = .init()
     static var tickCount: UInt64 {

--- a/XIV on Mac/Wine.swift
+++ b/XIV on Mac/Wine.swift
@@ -119,50 +119,50 @@ struct Wine {
             UserDefaults.standard.set(_retina, forKey: retinaSettingKey)
         }
     }
-	
-	private static let leftOptionIsAltSettingKey = "LeftOptionIsAlt"
-	static var leftOptionIsAlt: Bool {
-		get {
-			Util.getSetting(settingKey: leftOptionIsAltSettingKey, defaultValue: false)
-		}
-		set(_leftOpenIsAlt) {
-			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftOptionIsAlt", data: _leftOpenIsAlt ? "y" : "n")
-			UserDefaults.standard.set(_leftOpenIsAlt, forKey: leftOptionIsAltSettingKey)
-		}
-	}
-	
-	private static let rightOptionIsAltSettingKey = "RightOptionIsAlt"
-	static var rightOptionIsAlt: Bool {
-		get {
-			Util.getSetting(settingKey: rightOptionIsAltSettingKey, defaultValue: false)
-		}
-		set(_rightOpenIsAlt) {
-			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightOptionIsAlt", data: _rightOpenIsAlt ? "y" : "n")
-			UserDefaults.standard.set(_rightOpenIsAlt, forKey: rightOptionIsAltSettingKey)
-		}
-	}
-	
-	private static let leftCommandIsCtrlSettingKey = "LeftCommandIsCtrl"
-	static var leftCommandIsCtrl: Bool {
-		get {
-			Util.getSetting(settingKey: leftCommandIsCtrlSettingKey, defaultValue: false)
-		}
-		set(_leftCommandIsCtrl) {
-			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftCommandIsCtrl", data: _leftCommandIsCtrl ? "y" : "n")
-			UserDefaults.standard.set(_leftCommandIsCtrl, forKey: leftCommandIsCtrlSettingKey)
-		}
-	}
-	
-	private static let rightCommandIsCtrlSettingKey = "RightCommandIsCtrl"
-	static var rightCommandIsCtrl: Bool {
-		get {
-			Util.getSetting(settingKey: rightCommandIsCtrlSettingKey, defaultValue: false)
-		}
-		set(_rightCommandIsCtrl) {
-			addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightCommandIsCtrl", data: _rightCommandIsCtrl ? "y" : "n")
-			UserDefaults.standard.set(_rightCommandIsCtrl, forKey: rightCommandIsCtrlSettingKey)
-		}
-	}
+    
+    private static let leftOptionIsAltSettingKey = "LeftOptionIsAlt"
+    static var leftOptionIsAlt: Bool {
+        get {
+            Util.getSetting(settingKey: leftOptionIsAltSettingKey, defaultValue: false)
+        }
+        set(_leftOpenIsAlt) {
+            addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftOptionIsAlt", data: _leftOpenIsAlt ? "y" : "n")
+            UserDefaults.standard.set(_leftOpenIsAlt, forKey: leftOptionIsAltSettingKey)
+        }
+    }
+    
+    private static let rightOptionIsAltSettingKey = "RightOptionIsAlt"
+    static var rightOptionIsAlt: Bool {
+        get {
+            Util.getSetting(settingKey: rightOptionIsAltSettingKey, defaultValue: false)
+        }
+        set(_rightOpenIsAlt) {
+            addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightOptionIsAlt", data: _rightOpenIsAlt ? "y" : "n")
+            UserDefaults.standard.set(_rightOpenIsAlt, forKey: rightOptionIsAltSettingKey)
+        }
+    }
+    
+    private static let leftCommandIsCtrlSettingKey = "LeftCommandIsCtrl"
+    static var leftCommandIsCtrl: Bool {
+        get {
+            Util.getSetting(settingKey: leftCommandIsCtrlSettingKey, defaultValue: false)
+        }
+        set(_leftCommandIsCtrl) {
+            addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftCommandIsCtrl", data: _leftCommandIsCtrl ? "y" : "n")
+            UserDefaults.standard.set(_leftCommandIsCtrl, forKey: leftCommandIsCtrlSettingKey)
+        }
+    }
+    
+    private static let rightCommandIsCtrlSettingKey = "RightCommandIsCtrl"
+    static var rightCommandIsCtrl: Bool {
+        get {
+            Util.getSetting(settingKey: rightCommandIsCtrlSettingKey, defaultValue: false)
+        }
+        set(_rightCommandIsCtrl) {
+            addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightCommandIsCtrl", data: _rightCommandIsCtrl ? "y" : "n")
+            UserDefaults.standard.set(_rightCommandIsCtrl, forKey: rightCommandIsCtrlSettingKey)
+        }
+    }
     
     private static var timebase: mach_timebase_info = .init()
     static var tickCount: UInt64 {

--- a/XIV on Mac/de.lproj/Localizable.strings
+++ b/XIV on Mac/de.lproj/Localizable.strings
@@ -142,6 +142,7 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_TAB_ADVANCED_TITLE" = "Erweiterte Optionen";
 
 // General Settings tab items
+"SETTINGS_GENERAL_TITLE_LICENSE" = "License";
 "SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB" = "XIV on Mac kann mit Mac, Windows, oder Steam Spiellizenzen funktionieren. Du musst im Besitz der jeweiligen Lizenz sein, im Zweifelsfall kann der Account Status auf der Mogry-Station überprüft werden. Steam-Accounts müssen zuvor mit dem Final Fantasy XIV-Dienstkonto verknüpft worden sein, indem man sich auf einem Windows-PC anmeldet; zusätzlich muss außerdem die macOS-Version von Steam laufen.";
 "SETTINGS_LANGUAGE_PICKER" = "Sprache:";
 "SETTINGS_LANGUAGE_JAPANESE" = "Japanisch";
@@ -155,8 +156,18 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_FREE_TRIAL" = "Kostenlose Testversion";
 "SETTINGS_GENERAL_FREE_TRIAL_BLURB" = "Wenn du die kostenlose Testversion verwenden musst du denselben Lizenztyp wählen, den du bei der Anmeldung für die Testversion verwendet hast. Außerdem muss dein Final Fantasy XIV-Konto bereits eine aktive Testversion haben, da XIV on Mac dich nicht automatisch anmelden kann.";
 "SETTINGS_DOWNLOAD_LIMIT" = "Begrenzung der Download-Geschwindigkeit auf";
+"SETTINGS_GENERAL_TITLE_NETWORK" = "Network";
 "SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER" = "0.0";
 "SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/Sek";
+"SETTINGS_GENERAL_TITLE_INPUT" = "Key mapping";
+"SETTINGS_GENERAL_INPUT_LEFT_OPTION" = "Left option:";
+"SETTINGS_GENERAL_INPUT_RIGHT_OPTION" = "Right option:";
+"SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT" = "Windows alt";
+"SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION" = "macOS option";
+"SETTINGS_GENERAL_INPUT_LEFT_COMMAND" = "Left command:";
+"SETTINGS_GENERAL_INPUT_RIGHT_COMMAND" = "Right command:";
+"SETTINGS_GENERAL_INPUT_BUTTON_CTRL" = "Ctrl";
+"SETTINGS_GENERAL_INPUT_BUTTON_ALT" = "Alt";
 
 // Graphics Settings tab items
 "SETTINGS_FPS_LIMIT" = "Maximale Framerate";

--- a/XIV on Mac/en.lproj/Localizable.strings
+++ b/XIV on Mac/en.lproj/Localizable.strings
@@ -142,6 +142,7 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_TAB_ADVANCED_TITLE" = "Advanced";
 
 // General Settings tab items
+"SETTINGS_GENERAL_TITLE_LICENSE" = "License";
 "SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB" = "XIV on Mac can work with Mac, Windows, and Steam licenses. You must already own the license type you choose, if you are unsure you can check your account status through Mogstation. Steam accounts must have been previously linked to your Final Fantasy XIV service account by logging in on a Windows PC, and further require the macOS version of Steam to be running.";
 "SETTINGS_LANGUAGE_PICKER" = "Language:";
 "SETTINGS_LANGUAGE_JAPANESE" = "Japanese";
@@ -154,9 +155,20 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_PLATFORM_STEAM" = "Steam";
 "SETTINGS_FREE_TRIAL" = "Free Trial";
 "SETTINGS_GENERAL_FREE_TRIAL_BLURB" = "When using the Free Trial, you must choose the same license type you used when you signed up for the trial. Additionally, your Final Fantasy XIV account must already have an active trial, as XIV on Mac cannot sign you up automatically.";
+"SETTINGS_GENERAL_TITLE_NETWORK" = "Network";
 "SETTINGS_DOWNLOAD_LIMIT" = "Limit Download speed to";
 "SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER" = "0.0";
 "SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/sec";
+"SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/sec";
+"SETTINGS_GENERAL_TITLE_INPUT" = "Key mapping";
+"SETTINGS_GENERAL_INPUT_LEFT_OPTION" = "Left option:";
+"SETTINGS_GENERAL_INPUT_RIGHT_OPTION" = "Right option:";
+"SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT" = "Windows alt";
+"SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION" = "macOS option";
+"SETTINGS_GENERAL_INPUT_LEFT_COMMAND" = "Left command:";
+"SETTINGS_GENERAL_INPUT_RIGHT_COMMAND" = "Right command:";
+"SETTINGS_GENERAL_INPUT_BUTTON_CTRL" = "Ctrl";
+"SETTINGS_GENERAL_INPUT_BUTTON_ALT" = "Alt";
 
 // Graphics Settings tab items
 "SETTINGS_FPS_LIMIT" = "Maximum Frame Rate";

--- a/XIV on Mac/en.lproj/Localizable.strings
+++ b/XIV on Mac/en.lproj/Localizable.strings
@@ -159,7 +159,6 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_DOWNLOAD_LIMIT" = "Limit Download speed to";
 "SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER" = "0.0";
 "SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/sec";
-"SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/sec";
 "SETTINGS_GENERAL_TITLE_INPUT" = "Key mapping";
 "SETTINGS_GENERAL_INPUT_LEFT_OPTION" = "Left option:";
 "SETTINGS_GENERAL_INPUT_RIGHT_OPTION" = "Right option:";

--- a/XIV on Mac/fr.lproj/Localizable.strings
+++ b/XIV on Mac/fr.lproj/Localizable.strings
@@ -144,6 +144,7 @@ Ne l'activez pas sur les écrans autres que écrans Retina, sauf à des fins de 
 "SETTINGS_TAB_ADVANCED_TITLE" = "Avancé";
 
 // General Settings tab items
+"SETTINGS_GENERAL_TITLE_LICENSE" = "License";
 "SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB" = "XIV on Mac peut fonctionner avec les licences Mac, Windows et Steam. Vous devez posséder le type de licence que vous choisissez. Si vous n'êtes pas sûr, vérifiez l'état de votre compte via Mogstation. Les comptes Steam doivent avoir été précédemment liés à votre compte de service Final Fantasy XIV en vous connectant sur un PC Windows, et nécessitent en outre que la version macOS de Steam soit en cours d'exécution.";
 "SETTINGS_LANGUAGE_PICKER" = "Langue :";
 "SETTINGS_LANGUAGE_JAPANESE" = "Japonais";
@@ -156,9 +157,19 @@ Ne l'activez pas sur les écrans autres que écrans Retina, sauf à des fins de 
 "SETTINGS_PLATFORM_STEAM" = "Steam";
 "SETTINGS_FREE_TRIAL" = "Essai gratuit";
 "SETTINGS_GENERAL_FREE_TRIAL_BLURB" = "Lorsque vous utilisez l'essai gratuit, vous devez choisir le même type de licence que celui que vous avez utilisé lors de votre inscription à l'essai. De plus, votre compte Final Fantasy XIV doit déjà avoir un essai actif, car XIV sur Mac ne peut pas vous inscrire automatiquement.";
+"SETTINGS_GENERAL_TITLE_NETWORK" = "Network";
 "SETTINGS_DOWNLOAD_LIMIT" = "Limiter la vitesse de téléchargement à";
 "SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER" = "0.0";
 "SETTINGS_DOWNLOAD_LIMIT_UNITS" = "Mo/s";
+"SETTINGS_GENERAL_TITLE_INPUT" = "Key mapping";
+"SETTINGS_GENERAL_INPUT_LEFT_OPTION" = "Left option:";
+"SETTINGS_GENERAL_INPUT_RIGHT_OPTION" = "Right option:";
+"SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT" = "Windows alt";
+"SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION" = "macOS option";
+"SETTINGS_GENERAL_INPUT_LEFT_COMMAND" = "Left command:";
+"SETTINGS_GENERAL_INPUT_RIGHT_COMMAND" = "Right command:";
+"SETTINGS_GENERAL_INPUT_BUTTON_CTRL" = "Ctrl";
+"SETTINGS_GENERAL_INPUT_BUTTON_ALT" = "Alt";
 
 // Graphics Settings tab items
 "SETTINGS_FPS_LIMIT" = "Fréquence d'images maximale";

--- a/XIV on Mac/ja.lproj/Localizable.strings
+++ b/XIV on Mac/ja.lproj/Localizable.strings
@@ -144,6 +144,7 @@
 "SETTINGS_TAB_ADVANCED_TITLE" = "高度";
 
 // General Settings tab items
+"SETTINGS_GENERAL_TITLE_LICENSE" = "License";
 "SETTINGS_GENERAL_LANGUAGE_AND_LICENSE_BLURB" = "XIV on MacはMac版、Windows版、Steam版のライセンスで動作可能です。選択したライセンスを所有している必要があります。不明な場合はモグステーションでアカウントの状況を確認できます。なお、Steam版はあらかじめWindows PCでSteamとファイナルファンタジーXIVのサービスアカウントをリンクしておく必要があり、さらにmacOS版のSteamアプリをバックグラウンドで起動しておく必要があります。";
 "SETTINGS_LANGUAGE_PICKER" = "言語:";
 "SETTINGS_LANGUAGE_JAPANESE" = "日本語";
@@ -156,9 +157,19 @@
 "SETTINGS_PLATFORM_STEAM" = "Steam";
 "SETTINGS_FREE_TRIAL" = "フリートライアル";
 "SETTINGS_GENERAL_FREE_TRIAL_BLURB" = "フリートライアルを利用する場合、フリートライアルに登録した時と同じライセンスタイプを選択してください。また、XIV on Macは自動的にサインアップできないため、あなたのファイナルファンタジーXIVのアカウントで先にフリートライアルへの登録を済ませておく必要があります。";
+"SETTINGS_GENERAL_TITLE_NETWORK" = "Network";
 "SETTINGS_DOWNLOAD_LIMIT" = "ダウンロード速度を制限";
 "SETTINGS_DOWNLOAD_LIMIT_PLACEHOLDER" = "0.0";
 "SETTINGS_DOWNLOAD_LIMIT_UNITS" = "MB/秒";
+"SETTINGS_GENERAL_TITLE_INPUT" = "Key mapping";
+"SETTINGS_GENERAL_INPUT_LEFT_OPTION" = "Left option:";
+"SETTINGS_GENERAL_INPUT_RIGHT_OPTION" = "Right option:";
+"SETTINGS_GENERAL_INPUT_BUTTON_WINDOWS_ALT" = "Windows alt";
+"SETTINGS_GENERAL_INPUT_BUTTON_MACOS_OPTION" = "macOS option";
+"SETTINGS_GENERAL_INPUT_LEFT_COMMAND" = "Left command:";
+"SETTINGS_GENERAL_INPUT_RIGHT_COMMAND" = "Right command:";
+"SETTINGS_GENERAL_INPUT_BUTTON_CTRL" = "Ctrl";
+"SETTINGS_GENERAL_INPUT_BUTTON_ALT" = "Alt";
 
 // Graphics Settings tab items
 "SETTINGS_FPS_LIMIT" = "最大フレームレート";


### PR DESCRIPTION
I've really wanted to expose the LeftOptionIsAlt/RightOptionIsAlt and LeftCommandIsCtrl/RightCommandIsCtrl wine config options, to be able to use alt+key to write special characters on the international keyboard and use command+c/v for copy/paste. I've exposed those options in Wine.swift, and added them as options in the general settings UI.

I also changed the UI slightly to fit everything, and put some labels on the different sections. I wasn't to use what to call the option-button options, so I've gone with "Windows alt" or "macOS option" for now.

The one thing missing is adding these options to the NativeAOT config, because right now, they're reset every time you relaunch, but I haven't yet delved into that. I would have to look into how to even clone and compile it, which I can do eventually if needed. Feel free to reject the pull request if you want that supported first, or if this is an unwanted feature in general.