### PR TITLE
Fixes to the key mapping

### DIFF
--- a/XIV on Mac/Settings/SettingsGeneralTabView.swift
+++ b/XIV on Mac/Settings/SettingsGeneralTabView.swift
@@ -163,19 +163,19 @@ extension SettingsGeneralTabView {
             didSet { updateHTTPMaxSpeed() }
         }
         
-        @Published var leftOptionIsAlt: Bool = !Wine.leftOptionIsAlt {
+        @Published var leftOptionIsAlt: Bool = Wine.leftOptionIsAlt {
             didSet { Wine.leftOptionIsAlt = leftOptionIsAlt }
         }
         
-        @Published var rightOptionIsAlt: Bool = !Wine.rightOptionIsAlt {
+        @Published var rightOptionIsAlt: Bool = Wine.rightOptionIsAlt {
             didSet { Wine.rightOptionIsAlt = rightOptionIsAlt }
         }
         
-        @Published var leftCommandIsCtrl: Bool = !Wine.leftCommandIsCtrl {
+        @Published var leftCommandIsCtrl: Bool = Wine.leftCommandIsCtrl {
             didSet { Wine.leftCommandIsCtrl = leftCommandIsCtrl }
         }
         
-        @Published var rightCommandIsCtrl: Bool = !Wine.rightCommandIsCtrl {
+        @Published var rightCommandIsCtrl: Bool = Wine.rightCommandIsCtrl {
             didSet { Wine.rightCommandIsCtrl = rightCommandIsCtrl }
         }
 

--- a/XIV on Mac/Wine.swift
+++ b/XIV on Mac/Wine.swift
@@ -123,7 +123,7 @@ struct Wine {
     private static let leftOptionIsAltSettingKey = "LeftOptionIsAlt"
     static var leftOptionIsAlt: Bool {
         get {
-            Util.getSetting(settingKey: leftOptionIsAltSettingKey, defaultValue: false)
+            Util.getSetting(settingKey: leftOptionIsAltSettingKey, defaultValue: true)
         }
         set(_leftOpenIsAlt) {
             addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftOptionIsAlt", data: _leftOpenIsAlt ? "y" : "n")
@@ -134,7 +134,7 @@ struct Wine {
     private static let rightOptionIsAltSettingKey = "RightOptionIsAlt"
     static var rightOptionIsAlt: Bool {
         get {
-            Util.getSetting(settingKey: rightOptionIsAltSettingKey, defaultValue: false)
+            Util.getSetting(settingKey: rightOptionIsAltSettingKey, defaultValue: true)
         }
         set(_rightOpenIsAlt) {
             addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightOptionIsAlt", data: _rightOpenIsAlt ? "y" : "n")
@@ -145,7 +145,7 @@ struct Wine {
     private static let leftCommandIsCtrlSettingKey = "LeftCommandIsCtrl"
     static var leftCommandIsCtrl: Bool {
         get {
-            Util.getSetting(settingKey: leftCommandIsCtrlSettingKey, defaultValue: false)
+            Util.getSetting(settingKey: leftCommandIsCtrlSettingKey, defaultValue: true)
         }
         set(_leftCommandIsCtrl) {
             addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "LeftCommandIsCtrl", data: _leftCommandIsCtrl ? "y" : "n")
@@ -156,7 +156,7 @@ struct Wine {
     private static let rightCommandIsCtrlSettingKey = "RightCommandIsCtrl"
     static var rightCommandIsCtrl: Bool {
         get {
-            Util.getSetting(settingKey: rightCommandIsCtrlSettingKey, defaultValue: false)
+            Util.getSetting(settingKey: rightCommandIsCtrlSettingKey, defaultValue: true)
         }
         set(_rightCommandIsCtrl) {
             addReg(key: "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver", value: "RightCommandIsCtrl", data: _rightCommandIsCtrl ? "y" : "n")


### PR DESCRIPTION
I figured out why it looked like the registry values didn't get saved, it was just a bug on my side. Some bools got accidentally double-flipped, so it looked like it was working, but the inverse value got saved to defaults. Should be fixed now.