### PR TITLE
Pr/screen capture

### DIFF
--- a/XIV on Mac.xcodeproj/project.pbxproj
+++ b/XIV on Mac.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		0762AB922973AEB400A4D6E0 /* SettingsGraphicsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0762AB912973AEB400A4D6E0 /* SettingsGraphicsTabView.swift */; };
 		0762AB942973AED200A4D6E0 /* SettingsPluginsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0762AB932973AED200A4D6E0 /* SettingsPluginsTabView.swift */; };
 		0762AB962973AEF100A4D6E0 /* SettingsAdvancedTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0762AB952973AEF100A4D6E0 /* SettingsAdvancedTabView.swift */; };
+		0786F05A29BAD9E300009AD5 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 0786F05929BAD9E300009AD5 /* KeyboardShortcuts */; };
+		0786F05C29BADDA500009AD5 /* ScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786F05B29BADDA500009AD5 /* ScreenCapture.swift */; };
+		0786F05E29BBF67400009AD5 /* ScreenCaptureEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0786F05D29BBF67400009AD5 /* ScreenCaptureEngine.swift */; };
 		079A343027F90F350043BEEA /* FirstAidModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A342F27F90F350043BEEA /* FirstAidModel.swift */; };
 		079A343227FA59D90043BEEA /* FFXIVCFGEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079A343127FA59D90043BEEA /* FFXIVCFGEncoder.swift */; };
 		07A3498B2805689200A9D7D0 /* CfgCheckGood.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 07A349892805689200A9D7D0 /* CfgCheckGood.tiff */; };
@@ -24,6 +27,7 @@
 		07B3507129A4717B0010C1F5 /* INIReadWrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B3507029A4717B0010C1F5 /* INIReadWrite.swift */; };
 		07B3507329A4829C0010C1F5 /* ffxivbenchmarklauncher-Default.ini in Resources */ = {isa = PBXBuildFile; fileRef = 07B3507229A4829C0010C1F5 /* ffxivbenchmarklauncher-Default.ini */; };
 		07B529D527D97D2B005B78BF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 07B529D727D97D2B005B78BF /* Localizable.strings */; };
+		07B5C83729C7AFCC0092C5C6 /* SettingsCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B5C83629C7AFCC0092C5C6 /* SettingsCaptureView.swift */; };
 		07BF3AF728063A8600794155 /* CfgCheckProbFixed.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 07BF3AF628063A8600794155 /* CfgCheckProbFixed.tiff */; };
 		07BF3AFA2806507800794155 /* CfgCheckAdvFailed.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 07BF3AF82806507800794155 /* CfgCheckAdvFailed.tiff */; };
 		07BF3AFB2806507800794155 /* CfgCheckAdvFixed.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 07BF3AF92806507800794155 /* CfgCheckAdvFixed.tiff */; };
@@ -107,6 +111,8 @@
 		0762AB912973AEB400A4D6E0 /* SettingsGraphicsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGraphicsTabView.swift; sourceTree = "<group>"; };
 		0762AB932973AED200A4D6E0 /* SettingsPluginsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPluginsTabView.swift; sourceTree = "<group>"; };
 		0762AB952973AEF100A4D6E0 /* SettingsAdvancedTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAdvancedTabView.swift; sourceTree = "<group>"; };
+		0786F05B29BADDA500009AD5 /* ScreenCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapture.swift; sourceTree = "<group>"; };
+		0786F05D29BBF67400009AD5 /* ScreenCaptureEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureEngine.swift; sourceTree = "<group>"; };
 		079A342F27F90F350043BEEA /* FirstAidModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstAidModel.swift; sourceTree = "<group>"; };
 		079A343127FA59D90043BEEA /* FFXIVCFGEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFXIVCFGEncoder.swift; sourceTree = "<group>"; };
 		07A349892805689200A9D7D0 /* CfgCheckGood.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = CfgCheckGood.tiff; sourceTree = "<group>"; };
@@ -117,6 +123,7 @@
 		07B3507029A4717B0010C1F5 /* INIReadWrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = INIReadWrite.swift; sourceTree = "<group>"; };
 		07B3507229A4829C0010C1F5 /* ffxivbenchmarklauncher-Default.ini */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "ffxivbenchmarklauncher-Default.ini"; sourceTree = "<group>"; };
 		07B529D627D97D2B005B78BF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		07B5C83629C7AFCC0092C5C6 /* SettingsCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCaptureView.swift; sourceTree = "<group>"; };
 		07BF3AF628063A8600794155 /* CfgCheckProbFixed.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = CfgCheckProbFixed.tiff; sourceTree = "<group>"; };
 		07BF3AF82806507800794155 /* CfgCheckAdvFailed.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = CfgCheckAdvFailed.tiff; sourceTree = "<group>"; };
 		07BF3AF92806507800794155 /* CfgCheckAdvFixed.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = CfgCheckAdvFixed.tiff; sourceTree = "<group>"; };
@@ -193,6 +200,7 @@
 				50DF1F8827CD261A00DE9DA5 /* OrderedCollections in Frameworks */,
 				509D0E2D2960536A0055367A /* KeychainAccess in Frameworks */,
 				503B819C28394341006197C1 /* XIVLauncher.NativeAOT.dylib in Frameworks */,
+				0786F05A29BAD9E300009AD5 /* KeyboardShortcuts in Frameworks */,
 				509D0E302960540C0055367A /* AppMover in Frameworks */,
 				5049B9B3283CFEC600463A2B /* libsteam_api64.dylib in Frameworks */,
 				50D30FA327B93359007A9F66 /* Embassy in Frameworks */,
@@ -265,6 +273,8 @@
 				5049B9AD283BAFE600463A2B /* Log.swift */,
 				50511EC42770E085003A1E9F /* AppDelegate.swift */,
 				5010EFE327E4CE40001D2FEC /* Encryption.swift */,
+				0786F05B29BADDA500009AD5 /* ScreenCapture.swift */,
+				0786F05D29BBF67400009AD5 /* ScreenCaptureEngine.swift */,
 				50F8A5F827BFA93800ADC0CB /* Patcher */,
 				509A62D527A58966001B203A /* Launcher */,
 				509D4C4C29A4B993001961CC /* Benchmark */,
@@ -350,6 +360,7 @@
 			children = (
 				0762AB8D2973A09A00A4D6E0 /* SettingsView.swift */,
 				0762AB8F2973AE2000A4D6E0 /* SettingsGeneralTabView.swift */,
+				07B5C83629C7AFCC0092C5C6 /* SettingsCaptureView.swift */,
 				0762AB912973AEB400A4D6E0 /* SettingsGraphicsTabView.swift */,
 				0762AB932973AED200A4D6E0 /* SettingsPluginsTabView.swift */,
 				0762AB952973AEF100A4D6E0 /* SettingsAdvancedTabView.swift */,
@@ -407,6 +418,7 @@
 				50DC355D27E9CEEE00DBA62C /* Base32 */,
 				509D0E2C2960536A0055367A /* KeychainAccess */,
 				509D0E2F2960540C0055367A /* AppMover */,
+				0786F05929BAD9E300009AD5 /* KeyboardShortcuts */,
 			);
 			productName = "XIV on Mac";
 			productReference = 50511EC12770E085003A1E9F /* XIV on Mac.app */;
@@ -449,6 +461,7 @@
 				50B1C5B627D25620006DA54E /* XCRemoteSwiftPackageReference "swift-seeurl" */,
 				50DC355C27E9CEEE00DBA62C /* XCRemoteSwiftPackageReference "Base32" */,
 				509D0E2E2960540C0055367A /* XCRemoteSwiftPackageReference "AppMover" */,
+				0786F05829BAD9E300009AD5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 			);
 			productRefGroup = 50511EC22770E085003A1E9F /* Products */;
 			projectDirPath = "";
@@ -555,6 +568,7 @@
 				0762AB962973AEF100A4D6E0 /* SettingsAdvancedTabView.swift in Sources */,
 				2B7C95D2277C6C6000A3CA89 /* SocialIntegration.swift in Sources */,
 				5015D4C92881EAF9004BA6D8 /* AddOn.swift in Sources */,
+				07B5C83729C7AFCC0092C5C6 /* SettingsCaptureView.swift in Sources */,
 				5077A32C27C12A9100D4F1B8 /* Settings.swift in Sources */,
 				50E7EB9A29A16F29001BC287 /* Benchmark.swift in Sources */,
 				50BD278727785418002B0D1F /* Notifications.swift in Sources */,
@@ -562,8 +576,10 @@
 				509FE19A27E3654E008D56D6 /* FFXIVEnums.swift in Sources */,
 				5010EFE427E4CE40001D2FEC /* Encryption.swift in Sources */,
 				5020957927C9611A00BD76CC /* Patch.swift in Sources */,
+				0786F05C29BADDA500009AD5 /* ScreenCapture.swift in Sources */,
 				0762AB902973AE2000A4D6E0 /* SettingsGeneralTabView.swift in Sources */,
 				07B3507129A4717B0010C1F5 /* INIReadWrite.swift in Sources */,
+				0786F05E29BBF67400009AD5 /* ScreenCaptureEngine.swift in Sources */,
 				50E980DE2840A65000050151 /* RepairController.swift in Sources */,
 				50FC2DFF27F974D300871760 /* DxvkStateCache.swift in Sources */,
 				50DF1F8527CCB83300DE9DA5 /* FFXIVRepo.swift in Sources */,
@@ -867,6 +883,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0786F05829BAD9E300009AD5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		502A18DF27AABF8400144AB9 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess";
@@ -934,6 +958,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0786F05929BAD9E300009AD5 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0786F05829BAD9E300009AD5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
+		};
 		50692C8827B3D13700945593 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 50692C8727B3D13700945593 /* XCRemoteSwiftPackageReference "Sparkle" */;

--- a/XIV on Mac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/XIV on Mac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "branch" : "main",
+        "revision" : "d168f629edcd687383e18c908168520b4f156324"
+      }
+    },
+    {
       "identity" : "keychainaccess",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kishikawakatsumi/KeychainAccess",

--- a/XIV on Mac/ScreenCapture.swift
+++ b/XIV on Mac/ScreenCapture.swift
@@ -1,0 +1,263 @@
+//
+//  ScreenCapture.swift
+//  XIV on Mac
+//
+//  Created by Chris Backas on 3/9/23.
+//
+
+import Foundation
+import ScreenCaptureKit
+import OSLog
+import UserNotifications
+
+public enum ScreenCaptureCodec: Int {
+    case h264 = 0
+    case hevc = 1
+}
+
+// A few items available prior to 13.0 to reduce the need to have availability checks everywhere
+struct ScreenCaptureHelper
+{
+    public static var captureFolderPref : String = "ScreenCaptureDirectory"
+    public static var videoCodecPref : String = "ScreenCaptureCodec"
+
+    public static func chooseFolder() {
+        let openPanel = NSOpenPanel()
+        openPanel.message = NSLocalizedString("SELECT_CAPTURE_PATH_PANEL_MESSAGE", comment: "")
+        openPanel.showsResizeIndicator = true
+        openPanel.showsHiddenFiles = true
+        openPanel.canChooseDirectories = true
+        openPanel.canChooseFiles = false
+        openPanel.canCreateDirectories = false
+        openPanel.allowsMultipleSelection = false
+        openPanel.begin { response in
+            if response == .OK {
+                UserDefaults.standard.setValue(openPanel.url!.path, forKey: captureFolderPref)
+            }
+            openPanel.close()
+        }
+    }
+
+}
+
+@available(macOS 13.0, *)
+class ScreenCapture
+{
+    private let screenCaptureEngine = ScreenCaptureEngine()
+    private let avWriter : AVWriter = AVWriter()
+    private var isRecording : Bool = false
+    {
+        didSet {
+            Task {
+                await MainActor.run{
+                        let center = UNUserNotificationCenter.current()
+                        center.getNotificationSettings { settings in
+                            guard settings.authorizationStatus == .authorized else { return }
+                            let content = UNMutableNotificationContent()
+                            if self.isRecording
+                            {
+                                content.title = NSLocalizedString("NOTIFY_CAPTURE_TITLE", comment: "")
+                                content.subtitle = NSLocalizedString("NOTIFY_CAPTURE_STARTED_SUBTITLE", comment: "")
+                                content.body = String(format:NSLocalizedString("NOTIFY_CAPTURE_STARTED_BODY", comment: ""),"\(self.avWriter.currentRecordingURL?.lastPathComponent ?? "")")
+                            }
+                            else
+                            {
+                                content.title = NSLocalizedString("NOTIFY_CAPTURE_TITLE", comment: "")
+                                content.subtitle = NSLocalizedString("NOTIFY_CAPTURE_STOPPED_SUBTITLE", comment: "")
+                                content.body = String(format:NSLocalizedString("NOTIFY_CAPTURE_STOPPED_BODY", comment: ""),"\(self.avWriter.currentRecordingURL?.lastPathComponent ?? "")")
+                            }
+                            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1 , repeats: false)
+                            let request = UNNotificationRequest(identifier: "com.marzent.XIVOnMac.ScreenCapture", content: content, trigger: trigger)
+                            UNUserNotificationCenter.current().add(request)
+                        }
+                }
+            }
+        }
+    }
+
+    @MainActor
+    static func checkCapturePermissions() {
+        Task {
+            // Two permissions we need, only one of which is required.
+            let recordPermission = await hasRecordPermission()
+            var notifiyPermission : Bool = false
+
+            let center = UNUserNotificationCenter.current()
+            center.getNotificationSettings { settings in
+                notifiyPermission = settings.authorizationStatus == .authorized
+            }
+
+            let alert: NSAlert = .init()
+            alert.messageText = NSLocalizedString("SCREEN_CAPTURE_PERMISSION", comment: "")
+            if !notifiyPermission && !recordPermission
+            {
+                alert.informativeText = NSLocalizedString("SCREEN_CAPTURE_PERMISSION_HAVE_NONE", comment: "")
+            }
+            else if !notifiyPermission
+            {
+                alert.informativeText = NSLocalizedString("SCREEN_CAPTURE_PERMISSION_NO_NOTIFY", comment: "")
+            }
+            else if !recordPermission
+            {
+                alert.informativeText = NSLocalizedString("SCREEN_CAPTURE_PERMISSION_NO_RECORD", comment: "")
+            }
+            else
+            {
+                alert.informativeText = NSLocalizedString("SCREEN_CAPTURE_PERMISSION_HAVE_ALL", comment: "")
+            }
+            if (!recordPermission) {
+                alert.alertStyle = .critical
+            }
+            else {
+                alert.alertStyle = .informational
+            }
+            alert.addButton(withTitle: NSLocalizedString("BUTTON_OK", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("SCREEN_CAPTURE_PERMISSION_OPEN_PREF_BUTTON", comment: ""))
+            if !recordPermission {
+                alert.icon = NSImage(named: "CfgCheckProbFailed.tiff")
+            }
+            else if !notifiyPermission {
+                alert.icon = NSImage(named: "CfgCheckProblems.tiff")
+            }
+            else {
+                alert.icon = NSImage(named: "CfgCheckGood.tiff")
+            }
+            let result = alert.runModal()
+            if result == .alertSecondButtonReturn {
+                if !recordPermission {
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+                }
+                else {
+                    // Should/can we just ask for permission again instead? Doesn't seem to be an exposed way to go directory to notification pane
+                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference")!)
+                }
+            }
+        }
+    }
+    
+    static func hasRecordPermission() async -> Bool {
+            do {
+                // If the app doesn't have Screen Recording permission, this call generates an exception.
+                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                
+                return true
+            } catch {
+                Log.error("FFXIV Screencapture: No screen recording permissions")
+                return false
+            }
+    }
+    
+    var canRecord: Bool {
+        get async {
+            if await !ScreenCapture.hasRecordPermission()
+            {
+                Log.error("FFXIV Screencapture: Can't capture, no permission!")
+                return false
+            }
+            
+            // We're single-purpose here :D
+            if !FFXIVApp.running
+            {
+                Log.error("FFXIV Screencapture: Game is not running, nothing to capture.")
+                return false
+            }
+                    
+            return true
+        }
+    }
+    
+    func toggleScreenCapture()
+    {
+        if (isRecording)
+        {
+            stopCapture()
+        }
+        else
+        {
+            startCapture()
+        }
+    }
+    
+    func startCapture()
+    {
+        Task {
+            if await canRecord {
+                await doStartCapture()
+            }
+        }
+    }
+    
+    func stopCapture()
+    {
+        Task {
+            await screenCaptureEngine.stopCapture()
+            await MainActor.run{
+                isRecording = false
+            }
+        }
+    }
+    
+    private func filterWindows(_ windows: [SCWindow]) -> [SCWindow] {
+        //let gamePids : [pid_t] = Wine.pidsOf(processName: "ffxiv_dx11.exe")
+        return windows
+        // Would be BEST to use the pids from above to identify  the process properly, but that's returning Windows PIDs and
+        // currently I don't know how to map them to macOS pids. So we use a hacky filter for now...
+            .filter { $0.owningApplication?.applicationName ?? "" == "wine64-preloader" }
+            .filter { $0.title ?? "" == "FINAL FANTASY XIV" }
+        // We don't really expect more than 1, but just in case let's make the result stable
+            .sorted { $0.owningApplication?.processID ?? 0 < $1.owningApplication?.processID ?? 0 }
+    }
+
+    
+    private func refreshAvailableContent() async -> SCWindow? {
+        do {
+            // Retrieve the available screen content to capture.
+            let availableContent = try await SCShareableContent.excludingDesktopWindows(false,
+                                                                                        onScreenWindowsOnly: true)
+            let windows = filterWindows(availableContent.windows)
+
+            return windows.first
+            
+        } catch {
+            Log.error("FFXIV Screencapture: Failed to get the shareable content: \(error.localizedDescription)")
+        }
+        return nil
+    }
+
+    private func streamConfiguration(forWindow:SCWindow) -> SCStreamConfiguration {
+        let streamConfig = SCStreamConfiguration()
+        
+        // Configure audio capture.
+        streamConfig.capturesAudio = true
+        streamConfig.excludesCurrentProcessAudio = true
+        streamConfig.showsCursor = false // Hide mouse
+        
+        // Configure the window content width and height.
+        streamConfig.width = Int(forWindow.frame.width) * 2
+        streamConfig.height = Int(forWindow.frame.height) * 2
+        
+        // Increase the depth of the frame queue to ensure high fps at the expense of increasing
+        // the memory footprint of WindowServer.
+        streamConfig.queueDepth = 5
+        
+        return streamConfig
+    }
+
+    
+    func doStartCapture() async
+    {
+        guard let window : SCWindow = await refreshAvailableContent() else
+        {
+            Log.error("FFXIV Screencapture: No game windows found to capture")
+            return
+        }
+        
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        screenCaptureEngine.avWriter = self.avWriter
+        screenCaptureEngine.startCapture(configuration: streamConfiguration(forWindow: window), filter: filter)
+        await MainActor.run{
+            isRecording = true
+        }
+    }
+    
+}

--- a/XIV on Mac/ScreenCaptureEngine.swift
+++ b/XIV on Mac/ScreenCaptureEngine.swift
@@ -1,0 +1,243 @@
+import Foundation
+import AVFoundation
+import ScreenCaptureKit
+import Combine
+
+@available(macOS 13.0, *)
+class ScreenCaptureEngine: NSObject, @unchecked Sendable {
+    public var  avWriter : AVWriter?
+    private var stream: SCStream?
+    private let videoSampleBufferQueue = DispatchQueue(label: "com.marzent.XIVOnMac.VideoCapture")
+    private let audioSampleBufferQueue = DispatchQueue(label: "com.marzent.XIVOnMac.AudioCapture")
+    
+    /// - Tag: StartCapture
+    func startCapture(configuration: SCStreamConfiguration, filter: SCContentFilter) {
+        let streamOutput = CaptureEngineStreamOutput()
+        
+        do {
+            if let avWriter = self.avWriter
+            {
+                streamOutput.avWriter = avWriter
+                avWriter.startRecording(height: Int(configuration.height), width: Int(configuration.width))
+            }
+            stream = SCStream(filter: filter, configuration: configuration, delegate: streamOutput)
+            
+            // Add a stream output to capture screen content.
+            try stream?.addStreamOutput(streamOutput, type: .screen, sampleHandlerQueue: videoSampleBufferQueue)
+            try stream?.addStreamOutput(streamOutput, type: .audio, sampleHandlerQueue: audioSampleBufferQueue)
+            stream?.startCapture()
+            Log.information("XIV Screen Recording: ")
+        } catch {
+            Log.error("XIV Screen Recording: Failed to start screen recording \(error)")
+        }
+    }
+    
+    @discardableResult
+    func stopCapture() async -> URL? {
+        var result : URL? = nil
+        do {
+            try await stream?.stopCapture()
+        } catch {
+            Log.error("XIV Screen Recording: Error stopping screen recording \(error)")
+        }
+        if let avWriter = self.avWriter {
+            result = await avWriter.stopRecording()
+        }
+        return result
+    }
+    
+    func update(configuration: SCStreamConfiguration, filter: SCContentFilter) async {
+        do {
+            try await stream?.updateConfiguration(configuration)
+            try await stream?.updateContentFilter(filter)
+        } catch {
+            Log.error("Failed to update the stream session: \(String(describing: error))")
+        }
+    }
+}
+
+@available(macOS 13.0, *)
+private class CaptureEngineStreamOutput: NSObject, SCStreamOutput, SCStreamDelegate {
+    
+    public var avWriter : AVWriter?
+    
+    private func isValidFrame(for sampleBuffer: CMSampleBuffer) -> Bool {
+
+            guard let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer,
+                                                                                 createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+                  let attachments = attachmentsArray.first
+            else {
+                return false
+            }
+
+            guard let statusRawValue = attachments[SCStreamFrameInfo.status] as? Int,
+                  let status = SCFrameStatus(rawValue: statusRawValue),
+                  status == .complete
+            else {
+                return false
+            }
+
+            guard let pixelBuffer = sampleBuffer.imageBuffer else {
+                return false
+            }
+
+            // We don't need to use any of these, we're just sanity checking that they're there.
+            guard let _ = CVPixelBufferGetIOSurface(pixelBuffer)?.takeUnretainedValue(), // SurfaceRef/Backing IOSurface
+                  let contentRectDict = attachments[.contentRect],
+                  let _ = CGRect(dictionaryRepresentation: contentRectDict as! CFDictionary), // contentRect
+                  let _ = attachments[.contentScale] as? CGFloat, // contentScale
+                  let _ = attachments[.scaleFactor] as? CGFloat // scaleFactor
+            else {
+                return false
+            }
+
+            return true
+        }
+    
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of outputType: SCStreamOutputType) {
+        
+        // Return early if the sample buffer is invalid.
+        guard sampleBuffer.isValid else { return }
+        
+        // Determine which type of data the sample buffer contains.
+        switch outputType {
+        case .screen:
+            guard isValidFrame(for: sampleBuffer) else {
+                            return
+                        }
+            avWriter?.recordVideo(sampleBuffer: sampleBuffer)
+        case .audio:
+            avWriter?.recordAudio(sampleBuffer: sampleBuffer)
+        @unknown default:
+            fatalError("Encountered unknown stream output type: \(outputType)")
+        }
+    }
+    
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        Log.error("XIV Screen Recording: An error occurred while capturing: \(error)")
+    }
+}
+
+@available(macOS 13.0, *)
+class AVWriter {
+
+    private(set) var assetWriter: AVAssetWriter?
+    private var assetWriterVideoInput: AVAssetWriterInput?
+    private var assetWriterAudioInput: AVAssetWriterInput?
+
+    private(set) var isRecording = false
+    public var currentRecordingURL : URL? = nil
+
+    init() {}
+
+    private func getRecordingPath() -> URL {
+        
+        let recordingLocation : URL
+        if let savedStringLocation = UserDefaults.standard.string(forKey: ScreenCaptureHelper.captureFolderPref) {
+            recordingLocation = URL(filePath: savedStringLocation)
+        }
+        else
+        {
+            recordingLocation = FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask)[0]
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HHmmss"
+        formatter.timeZone = NSTimeZone.local
+        let now = Date()
+        let formatted = formatter.string(from: now)
+        let filename = "XIV On Mac Recording \(formatted).mov"
+        
+        // I *suppose* the most correct thing to do is check for duplicates but hardly seems worth the effort with the timestamp.
+        let finalPath : URL = recordingLocation.appending(component: filename)
+        Log.information("Screen Recording: Creating new recording at \(finalPath)")
+        return finalPath
+    }
+
+    func startRecording(height: Int, width: Int) {
+        let filePath = getRecordingPath()
+        currentRecordingURL = filePath
+        guard let assetWriter = try? AVAssetWriter(url: filePath, fileType: .mov) else {
+            return
+        }
+
+        // Add an audio input
+        let audioSettings = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44100,
+            AVNumberOfChannelsKey: 2,
+        ] as [String: Any]
+
+        let assetWriterAudioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+        assetWriterAudioInput.expectsMediaDataInRealTime = true
+        assetWriter.add(assetWriterAudioInput)
+
+        var chosenCodec : AVVideoCodecType
+        switch ScreenCaptureCodec(rawValue: UserDefaults.standard.integer(forKey: ScreenCaptureHelper.videoCodecPref))
+        {
+            case .hevc:
+                chosenCodec = AVVideoCodecType.hevc
+            default:
+                chosenCodec = AVVideoCodecType.h264
+        }
+        let videoSettings = [
+            AVVideoCodecKey: chosenCodec,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height
+        ] as [String: Any]
+
+        // Add a video input
+        let assetWriterVideoInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        assetWriterVideoInput.expectsMediaDataInRealTime = true
+        assetWriter.add(assetWriterVideoInput)
+
+        self.assetWriter = assetWriter
+        self.assetWriterAudioInput = assetWriterAudioInput
+        self.assetWriterVideoInput = assetWriterVideoInput
+        isRecording = true
+    }
+
+    func stopRecording() async -> URL? {
+        guard let assetWriter = assetWriter else {
+            return nil
+        }
+
+        self.isRecording = false
+        self.assetWriter = nil
+
+        await assetWriter.finishWriting()
+        return assetWriter.outputURL
+    }
+
+    func recordVideo(sampleBuffer: CMSampleBuffer) {
+        guard isRecording,
+              let assetWriter = assetWriter
+        else {
+            return
+        }
+
+        if assetWriter.status == .unknown {
+            assetWriter.startWriting()
+            assetWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+        } else if assetWriter.status == .writing {
+            if let input = assetWriterVideoInput,
+               input.isReadyForMoreMediaData {
+                input.append(sampleBuffer)
+            }
+        } else {
+            Log.error("Error writing video - \(assetWriter.error?.localizedDescription ?? "Unknown error")")
+        }
+    }
+    
+    func recordAudio(sampleBuffer: CMSampleBuffer) {
+        guard isRecording,
+              let assetWriter = assetWriter,
+              assetWriter.status == .writing,
+              let input = assetWriterAudioInput,
+              input.isReadyForMoreMediaData
+        else {
+            return
+        }
+
+        input.append(sampleBuffer)
+    }
+}

--- a/XIV on Mac/Settings/SettingsCaptureView.swift
+++ b/XIV on Mac/Settings/SettingsCaptureView.swift
@@ -1,0 +1,67 @@
+//
+//  SettingsCaptureView.swift
+//  XIV on Mac
+//
+//  Created by Chris Backas on 3/19/23.
+//
+
+import SwiftUI
+import KeyboardShortcuts
+
+struct SettingsCaptureView: View {
+    
+    @AppStorage(ScreenCaptureHelper.captureFolderPref, store: .standard) var captureFolder : String = (FileManager.default.urls(for: .moviesDirectory, in: .userDomainMask)[0] as NSURL).path ?? ""
+    @AppStorage(ScreenCaptureHelper.videoCodecPref, store: .standard) var codecType : ScreenCaptureCodec = .h264
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text("SETTINGS_CAPTURE_PERMISSIONS_CHECK")
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            HStack {
+                Button("SETTINGS_CAPTURE_PERMISSIONS_CHECK_BUTTON"){
+                    if #available(macOS 13.0, *) {
+                        ScreenCapture.checkCapturePermissions()
+                    }
+                }.fixedSize()
+                Spacer()
+            }
+            HStack
+            {
+                Text("CAPTURE_FOLDER_LABEL")
+                Text(captureFolder)
+                    .frame(minWidth: 200)
+                Spacer()
+                Button("CAPTURE_FOLDER_SELECT_BUTTON")
+                {
+                    ScreenCaptureHelper.chooseFolder()
+                }
+            }
+
+            HStack {
+                KeyboardShortcuts.Recorder(NSLocalizedString("SETTINGS_TOGGLE_SCREEN_RECORDING",comment: ""), name: .toggleVideoCapture)
+                Spacer()
+            }
+            
+            HStack {
+                Picker(selection: $codecType, label: Text("SETTINGS_CAPTURE_CODEC")) {
+                    Text("SETTINGS_CAPTURE_CODEC_H264").tag(ScreenCaptureCodec.h264)
+                    Text("SETTINGS_CAPTURE_CODEC_HEVC").tag(ScreenCaptureCodec.hevc)
+                }.pickerStyle(RadioGroupPickerStyle())
+                Spacer()
+            }
+
+            Spacer()
+        }.padding()
+    }
+}
+
+struct SettingsCaptureView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsCaptureView()
+    }
+}

--- a/XIV on Mac/Settings/SettingsView.swift
+++ b/XIV on Mac/Settings/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @State private var selectedSettingsTab: SettingsTabItem = .General
 
     private var generalTabView: SettingsGeneralTabView = .init()
+    private var captureView: SettingsCaptureView = .init()
     private var graphicsTabView: SettingsGraphicsTabView = .init()
     private var pluginsTabView: SettingsPluginsTabView = .init()
     private var advancedTabView: SettingsAdvancedTabView = .init()
@@ -18,6 +19,9 @@ struct SettingsView: View {
     var body: some View {
         TabView(selection: $selectedSettingsTab) {
             generalTabView.tabItem { Text("SETTINGS_TAB_GENERAL_TITLE") }.tag(SettingsTabItem.General)
+            if #available(macOS 13.0, *) {
+                captureView.tabItem { Text("SETTINGS_TAB_CAPTURE_TITLE") }.tag(SettingsTabItem.Capture)
+            }
             graphicsTabView.tabItem { Text("SETTINGS_TAB_GRAPHICS_TITLE") }.tag(SettingsTabItem.Graphics)
             pluginsTabView.tabItem { Text("SETTINGS_TAB_PLUGINS_TITLE") }.tag(SettingsTabItem.Plugins)
             advancedTabView.tabItem { Text("SETTINGS_TAB_ADVANCED_TITLE") }.tag(SettingsTabItem.Advanced)
@@ -35,6 +39,7 @@ struct SettingsWindow_Previews: PreviewProvider {
 
 private enum SettingsTabItem: Hashable {
     case General
+    case Capture
     case Graphics
     case Plugins
     case Advanced

--- a/XIV on Mac/Util.swift
+++ b/XIV on Mac/Util.swift
@@ -8,6 +8,11 @@
 import AppKit
 import IOKit
 import SwiftUI
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    static let toggleVideoCapture = Self("toggleVideoCapture")
+}
 
 struct Util {
     @available(*, unavailable) private init() {}

--- a/XIV on Mac/en.lproj/Localizable.strings
+++ b/XIV on Mac/en.lproj/Localizable.strings
@@ -137,6 +137,7 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 
 "SETTINGS_WINDOW_TITLE" = "Settings";
 "SETTINGS_TAB_GENERAL_TITLE" = "General";
+"SETTINGS_TAB_CAPTURE_TITLE" = "Screen Capture";
 "SETTINGS_TAB_GRAPHICS_TITLE" = "Graphics";
 "SETTINGS_TAB_PLUGINS_TITLE" = "Plugins (Dalamud)";
 "SETTINGS_TAB_ADVANCED_TITLE" = "Advanced";
@@ -168,6 +169,29 @@ Do not enable this on non-retina displays, unless for screenshot purposes.";
 "SETTINGS_GENERAL_INPUT_RIGHT_COMMAND" = "Right command:";
 "SETTINGS_GENERAL_INPUT_BUTTON_CTRL" = "Ctrl";
 "SETTINGS_GENERAL_INPUT_BUTTON_ALT" = "Alt";
+
+// Screen Capture tab items
+"SETTINGS_TOGGLE_SCREEN_RECORDING" = "Start/Stop Screen Recording";
+"SETTINGS_CAPTURE_PERMISSIONS_CHECK" = "XIV On Mac requires permission to capture your screen. If you wish to receive a notification when screen recording has started or stopped, notification permissions must also be granted.";
+"SETTINGS_CAPTURE_PERMISSIONS_CHECK_BUTTON" = "Check Permissions…";
+"CAPTURE_FOLDER_LABEL" = "Capture Location:";
+"CAPTURE_FOLDER_SELECT_BUTTON" = "Select…";
+"SELECT_CAPTURE_PATH_PANEL_MESSAGE" = "Choose a folder to store new screen captures in.";
+"SETTINGS_CAPTURE_CODEC" = "Video Codec:";
+"SETTINGS_CAPTURE_CODEC_H264" = "H.264";
+"SETTINGS_CAPTURE_CODEC_HEVC" = "HEVC";
+"SCREEN_CAPTURE_PERMISSION" = "Screen Capture Permissions";
+"SCREEN_CAPTURE_PERMISSION_HAVE_NONE" = "XIV On Mac requires Screen Capture permission in order to record. You might also want to grant Notification permission to find out when recording has started or stopped.";
+"SCREEN_CAPTURE_PERMISSION_NO_NOTIFY" = "XIV On Mac required Notification permission to inform you when recording has started or stopped. Screen recording will still work without this permission.";
+"SCREEN_CAPTURE_PERMISSION_NO_RECORD" = "XIV On Mac requires Screen Capture permission in order to record.";
+"SCREEN_CAPTURE_PERMISSION_HAVE_ALL" = "XIV On Mac has all the permissions it needs!";
+"SCREEN_CAPTURE_PERMISSION_OPEN_PREF_BUTTON" = "Open Security Settings…";
+"NOTIFY_CAPTURE_TITLE" = "Screen Capture";
+"NOTIFY_CAPTURE_STARTED_SUBTITLE" = "Started Screen Recording";
+"NOTIFY_CAPTURE_STARTED_BODY" = "Recording to %@";
+"NOTIFY_CAPTURE_STOPPED_SUBTITLE" = "Stopped Screen Recording";
+"NOTIFY_CAPTURE_STOPPED_BODY" = "Recording saved to %@";
+
 
 // Graphics Settings tab items
 "SETTINGS_FPS_LIMIT" = "Maximum Frame Rate";


### PR DESCRIPTION
Adds a screen record/capture feature. Assign a hotkey to press in-game which will begin capturing the game's window and audio and saving it to a movie file of your choice. Press the hot key again to stop.
This will capture ONLY the game window regardless of what's on your screen, so floating windows are never included and the game can even continue recording when in the background. Compared to built-in Command-Shift-5 screen capturing, this makes it much easier to capture JUST the game in full-screen mode, and no longer requires weird audio plugins to enable audio capture.

Notes:
- Requires Screen Capture TCC permissions (of course)
- Requires macOS 13.0 or better (On earlier releases the feature will simply not be available)
- Based heavily on Apple's ScreenCaptureKit example code
- Added new dependency on KeyboardShortcuts module, since it does a lot of the groundwork we'd need to do for a proper global hotkey in a very nicely made package.