### PR TITLE
Update base game version

### DIFF
--- a/XIV on Mac/InstallerController.swift
+++ b/XIV on Mac/InstallerController.swift
@@ -183,7 +183,7 @@ class InstallerController: NSViewController {
     
     func install() {
         DispatchQueue.global(qos: .userInitiated).async { [self] in
-            let version = "1.0.8"
+            let version = "1.1.2"
             let url = URL(string: "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-\(version).zip")!
             do {
                 try HTTPClient.fetchFile(url: url) { total, now, _ in


### PR DESCRIPTION
1) Update base game version to 1.1.2 as 1.0.8 is starting to be taken down.