### PR TITLE
feat: add game controller metadata to Info.plist

### DIFF
--- a/XIV-on-Mac-Info.plist
+++ b/XIV-on-Mac-Info.plist
@@ -8,5 +8,22 @@
 	<string>https://softwareupdate.xivmac.com/sites/default/files/update_data/xivonmac_appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>bIfpzHYfcNKzabG5e14h/Y6dX4/u3zF2hMSQec7e5JA=</string>
+	<key>GCSupportedGameControllers</key>
+	<array>
+		<dict>
+			<key>ProfileName</key>
+			<string>ExtendedGamepad</string>
+		</dict>
+		<dict>
+			<key>ProfileName</key>
+			<string>MicroGamepad</string>
+		</dict>
+		<dict>
+			<key>ProfileName</key>
+			<string>DirectionalGamepad</string>
+		</dict>
+	</array>
+	<key>GCSupportsControllerUserInteraction</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
**Description**
This PR registers game controller support in Info.plist to fix controller detection and mapping issues on modern macOS versions. My controllers were completely undetected by Wine before making this change using the latest version on a Macbook Air M5, while a native Wine install could detect the controllers without issue.

**Changes**
- Added GCSupportedGameControllers declaring support for ExtendedGamepad, MicroGamepad, and DirectionalGamepad controller profiles.
- Added GCSupportsControllerUserInteraction set to `true` to indicate controller support.
- Note on Bluetooth Permissions: I have intentionally omitted the NSBluetoothAlwaysUsageDescription and NSBluetoothPeripheralUsageDescription keys. Because the launcher and Wine handle controller inputs through high-level frameworks (GameController / IOHIDManager) rather than direct CoreBluetooth radio access, these keys are not required. Excluding them prevents users from receiving unnecessary security permission prompts when launching the app.

**Verification**
- Verified that the local build compiles successfully (xcodebuild succeeds).
- Verified that gamepads are correctly recognized and inputs are routed properly through the new build (Button routing depends on game settings/calibration)
  - Tested with 8BitDo Pro 3 (in Xbox and Switch Bluetooth mode), Playstation4, Playstation5 controllers on Macbook Air M5